### PR TITLE
IE 7 でスクリプトエラーが発生する問題を修正しました

### DIFF
--- a/jQueryAutoHeight.js
+++ b/jQueryAutoHeight.js
@@ -31,8 +31,8 @@
         }
 
         // 要素の高さを取得
-        var hList = self.map(function(){
-            return $(this).height();
+        var hList = $.map(self, function (e) {
+            return $(e).height();
         });
         var hListLine = [];
         if (op.column > 1) {

--- a/jQueryAutoHeight.js
+++ b/jQueryAutoHeight.js
@@ -26,7 +26,7 @@
         },options || {}); // optionsに値があれば上書きする
 
         var self = $(this);
-        if (op.reset == 'reset') {
+        if (op.reset === 'reset') {
             self.removeAttr('style');
         }
 
@@ -44,7 +44,7 @@
         }
 
         // 高さの最大値を要素に適用
-        var ie6 = typeof window.addEventListener == "undefined" && typeof document.documentElement.style.maxHeight == "undefined";
+        var ie6 = typeof window.addEventListener === "undefined" && typeof document.documentElement.style.maxHeight === "undefined";
         if (op.column > 1) {
             for (var j=0; j<hListLine.length; j++) {
                 for (var k=0; k<op.column; k++) {
@@ -53,7 +53,7 @@
                     } else {
                         self.eq(j*op.column+k).css(op.height,hListLine[j]);
                     }
-                    if (k == 0 && op.clear != 0) {
+                    if (k === 0 && op.clear !== 0) {
                         self.eq(j*op.column+k).css('clear','both');
                     }
                 }


### PR DESCRIPTION
`Math.max.apply` の引数に `jQuery` オブジェクトを渡していたことが原因で IE7 でエラーが起きていたため、jQuery オブジェクトではなく配列を渡すように変更しました。

具体的な修正箇所は、エラーの原因となっていた変数 `hList` を生成する箇所です。
修正前のソースでは [.map()](http://s3pw.com/jQ-JPN/map/) メソッド (※ jQuery オブジェクトを返す) を使って生成していましたが、これを [$.map()](http://s3pw.com/jQ-JPN/jquery.map/) (※ 配列を返す) に差し替えました。

その他 `==` 演算子を `===` に置き換える等のリファクタリングも行いました。
## 参考文献
- [.map() - jQuery API Documentation 日本語訳](http://s3pw.com/jQ-JPN/map/)
- [$.map() - jQuery API Documentation 日本語訳](http://s3pw.com/jQ-JPN/jquery.map/)
- [Function.prototype.apply() - JavaScript | MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Function/apply)
